### PR TITLE
Fix MB35/60 deprecation (?)

### DIFF
--- a/Gamedata/ROEnginesExtended/PartConfigs/MB35_SSTU.cfg
+++ b/Gamedata/ROEnginesExtended/PartConfigs/MB35_SSTU.cfg
@@ -7,7 +7,7 @@
 
 	@engineType = MB35
 }
-@PART[ROEE-MB35]:AFTER[RealismOverhaulEngines]
+@PART[ROEE-MB35]:BEFORE[RealismOverhaulEnginesPost]
 {
 	@title = Deprecated
 	@description = Please use the new MB-35 model from ROEngines instead. This part will be removed in the future.

--- a/Gamedata/ROEnginesExtended/PartConfigs/MB60_SSTU.cfg
+++ b/Gamedata/ROEnginesExtended/PartConfigs/MB60_SSTU.cfg
@@ -7,7 +7,7 @@
 
 	@engineType = MB60
 }
-@PART[ROEE-MB60]:AFTER[RealismOverhaulEngines]
+@PART[ROEE-MB60]:BEFORE[RealismOverhaulEnginesPost]
 {
 	@title = Deprecated
 	@description = Please use the new MB-60 model from ROEngines instead. This part will be removed in the future.


### PR DESCRIPTION
Actually, the pass change shouldn't have touched this, for some reason the partconfig files in the release .zip are completely missing the deprecation block and the AFTER[RealismOverhaulEngines] should just work if present? Not sure what's going on.