### PR TITLE
Add part config for S5.4

### DIFF
--- a/Gamedata/ROEnginesExtended/PartConfigs/S5_4.cfg
+++ b/Gamedata/ROEnginesExtended/PartConfigs/S5_4.cfg
@@ -1,0 +1,9 @@
++PART[RO-KDU414]:BEFORE[RealismOverhaulEngines]:NEEDS[ROEngines]
+{
+	@name = ROEE-S5_4
+	@tags = Vostok
+	
+	@rescaleFactor *= 1
+
+	@engineType = S5_4
+}

--- a/Gamedata/ROEnginesExtended/Waterfall/Hypergolic/S5_4.cfg
+++ b/Gamedata/ROEnginesExtended/Waterfall/Hypergolic/S5_4.cfg
@@ -1,0 +1,13 @@
+@PART[ROEE-S5_4]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        moduleID = #$/name$-s5.4
+        template = waterfall-hypergolic-white-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.2, 0.2, 0.3
+        glow = ro-hypergolic-white
+    }
+}


### PR DESCRIPTION
Adds a part config using an inherited generic thruster model from the S5.19. The scale is correct with respect to the Vostok service module.